### PR TITLE
Fix createCheckoutSession function to work

### DIFF
--- a/php/ap_sample_createCheckoutSession.php
+++ b/php/ap_sample_createCheckoutSession.php
@@ -8,19 +8,19 @@
     $store_id = $_POST['store_id'];
     $idempotency_key = $_POST['idempotency_key'];
 
-    $webCheckoutDetail = array('checkoutReviewReturnUrl' => $checkout_review_return_url);
+    $webCheckoutDetails = array('checkoutReviewReturnUrl' => $checkout_review_return_url);
 
     if (null != $checkout_result_return_url) {
-        $webCheckoutDetail = array_merge($webCheckoutDetail, array('checkoutResultReturnUrl' => $checkout_result_return_url));
+        $webCheckoutDetails = array_merge($webCheckoutDetails, array('checkoutResultReturnUrl' => $checkout_result_return_url));
     }
 
     $payload = array_merge(
-        array('webCheckoutDetail' => $webCheckoutDetail),
+        array('webCheckoutDetails' => $webCheckoutDetails),
         array('storeId' => $store_id)
     );
 
     try {
-
+        $headers = array('x-amz-pay-Idempotency-Key' => $idempotency_key);
         $client = new Amazon\Pay\API\Client($amazonpay_config);
         $result = $client->createCheckoutSession($payload, $headers);
         $response = $result['response'];

--- a/php/ap_sample_createCheckoutSession.php
+++ b/php/ap_sample_createCheckoutSession.php
@@ -23,7 +23,7 @@
         $headers = array('x-amz-pay-Idempotency-Key' => $idempotency_key);
         $client = new Amazon\Pay\API\Client($amazonpay_config);
         $result = $client->createCheckoutSession($payload, $headers);
-        $response = $result['response'];
+        $response = '{"status":' . $result['status'] . ',"response":' . $result['response'] . '}';
 
         echo($response);
 


### PR DESCRIPTION
### PR Description
Hi, thank you for providing us the useful sample code to play around with some AmazonPay functions.
I found some problems breaking createCheckoutSession function.

### What I changed
* The parameter `webCheckoutDetail` should be `webCheckoutDetails`.
* The header has to include `x-amz-pay-Idempotency-Key`.
* The response should include HTTP status because `status` value is referred from `tester_createCheckoutSession.html` javascript.

Could you please check it? Thank you!

